### PR TITLE
Moved return to top button

### DIFF
--- a/bank_app/src/components/ReturnToTop.jsx
+++ b/bank_app/src/components/ReturnToTop.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { LiaArrowUpSolid } from "react-icons/lia";
 
 const ArrowBtn = (props) => (
-    <div className={`fixed bottom-[4%] right-[2%] z-10 rounded-full border-[2.5px] border-gray-500 hover:border-secondary ${props.styles}`}>
+    <div className={`fixed bottom-[15%] right-[2%] z-10 rounded-full border-[2.5px] border-gray-500 hover:border-secondary ${props.styles}`}>
         <a href="#home">
             <LiaArrowUpSolid
                 className="bg-primary text-[5rem] p-4 rounded-full cursor-pointer text-gray-500 hover:text-secondary" 
@@ -29,7 +29,7 @@ const ReturnToTop = () => {
 
     return (
         <>
-        {(scrollPosition > 150 ) && (
+        {(scrollPosition > 300 ) && (
                 <ArrowBtn styles='max_lg:hidden' />
         )}
 


### PR DESCRIPTION
- Moved return to top button because it was blocking the social links on medium devices.